### PR TITLE
Suggesting several improvements - avoiding unecessary FROM and COPY clauses in Container file and use .dockerignore file in a proper way.

### DIFF
--- a/files/.dockerignore
+++ b/files/.dockerignore
@@ -1,0 +1,10 @@
+# Ignore everything
+*
+# Allow only needed files and directories
+!/templates
+!/app.py
+!/cleaningredients.py
+!/default
+!/dependencies.txt
+!/food.txt
+!/words-by-frequency.txt

--- a/files/Containerfile
+++ b/files/Containerfile
@@ -1,19 +1,15 @@
-FROM redhat/ubi8
 FROM python
+
 LABEL maintainer="akeenan@redhat.com"
 
-COPY dependencies.txt dependencies.txt
-RUN pip3 install -r dependencies.txt
-RUN python3 -m spacy download en_core_web_sm
+WORKDIR /publish
 
 COPY . .
+
+RUN pip3 install -r dependencies.txt
+
+RUN python3 -m spacy download en_core_web_sm
+
 CMD ["python3", "-m" , "flask", "run", "--host=0.0.0.0"]
 
 EXPOSE 5000
-#CMD [ "nginx", "-g" , "daemon off;" ]
-
-
-
-
-
-  

--- a/files/templates/home.html
+++ b/files/templates/home.html
@@ -93,7 +93,7 @@
 <body class="body">
   <div class="wrapper">
     <h1 class="title">Search Recipes:</h1>
-      <form action = "http://localhost:5000/result" method = "post">
+      <form action = "/result" method = "post">
         <div class="search-form">
           <input class="url-search" type="url" placeholder="Recipe URL here..." name=url>
           <br>


### PR DESCRIPTION
In a Container file, if there are two FROM clauses, the first one will be ignored. Given that ‘COPY . .’ is already present, an additional copy command is not required. It is considered better practice to properly configure the .dockerignore file, initially restricting everything and subsequently permitting only the necessary elements. Also it is better for action to not have a hardcoded port because port of the application can be changed. Apart from that it is a good practice to use WORKDIR  instruction. WORKDIR  instructions sets the working directory for any RUN, CMD, ENTRYPOINT, COPY and ADD instructions that follow it in the Containerfile.